### PR TITLE
Remove Forinthy Dungeon

### DIFF
--- a/resources/locations.json
+++ b/resources/locations.json
@@ -120,7 +120,6 @@
         { "name": "Fishing Platform", "coords": [2772, 3283, 0], "size": "default" },
         { "name": "Flax", "coords": [2744, 3443, 0], "size": "default" },
         { "name": "Foodhall", "coords": [1842, 3746, 0], "size": "default" },
-        { "name": "Forinthry Dungeon", "coords": [3211, 10150, 0], "size": "default" },
         { "name": "Fountain of Rune", "coords": [3378, 3891, 0], "size": "default" },
         { "name": "Forthos Ruin", "coords": [1674, 3574, 0], "size": "default" },
         { "name": "Forthos Dungeon", "coords": [1819, 9951, 0], "size": "default" },


### PR DESCRIPTION
This area has been renamed to the Revenant Caves and this duplicate entry results in name overlapping on the map (see below)

![image](https://user-images.githubusercontent.com/5704760/170741766-ad5b5be4-773f-4204-99f1-037ea8035fec.png)
