### PR TITLE
Add Wilderness Slayer Cave to Locations

### DIFF
--- a/resources/locations.json
+++ b/resources/locations.json
@@ -378,6 +378,7 @@
         { "name": "White Knights' Castle", "coords": [2969, 3341, 0], "size": "default" },
         { "name": "White Wolf Mountain", "coords": [2847, 3494, 0], "size": "default" },
         { "name": "Wilderness", "coords": [3144, 3775, 0], "size": "large" },
+        { "name": "Wilderness Slayer Cave", "coords": [3392, 10102, 0], "size": "default"},
         { "name": "Wintertodt", "coords": [1630, 4004, 0], "size": "medium" },
         { "name": "Witchaven", "coords": [2709, 3289, 0], "size": "default" },
         { "name": "Witchaven Dungeon", "coords": [2722, 9689, 0], "size": "default" },


### PR DESCRIPTION
This area is currently not labeled (see below for more info)

Proposed area: https://explv.github.io/?centreX=3392&centreY=10101&centreZ=0&zoom=8

Wiki: https://oldschool.runescape.wiki/w/Wilderness_Slayer_Cave

![image](https://user-images.githubusercontent.com/5704760/171090569-c4bf0ffa-4960-4daf-b231-be903c6577b4.png)
